### PR TITLE
Relax peer dependencies to react@16.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/react-scrolling-background/pull/XX)
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#2](https://github.com/compulim/react-scrolling-background/pull/2)
 - Updated pull request validation to test against various React versions, in PR [#1](https://github.com/compulim/react-scrolling-background/pull/1)
    - Moved from JSX Runtime to JSX Classic to support testing against React 16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#XX](https://github.com/compulim/react-scrolling-background/pull/XX)
 - Updated pull request validation to test against various React versions, in PR [#1](https://github.com/compulim/react-scrolling-background/pull/1)
    - Moved from JSX Runtime to JSX Classic to support testing against React 16

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -14,6 +14,29 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^16",
+      "react": "16.8.0",
+      "react-test-renderer": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^17",
+      "react": "17.0.0",
+      "react-test-renderer": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "react": "18.0.0",
+      "react-test-renderer": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "react-scrolling-background": "^0.0.0-0"
   },

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -16,6 +16,36 @@
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",
+  "switch:react:16": {
+    "devDependencies": {
+      "@types/react": "^16",
+      "@types/react-dom": "^16"
+    },
+    "dependencies": {
+      "react": "16.8.0",
+      "react-dom": "16.8.0"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@types/react": "^17",
+      "@types/react-dom": "^17"
+    },
+    "dependencies": {
+      "react": "17.0.0",
+      "react-dom": "17.0.0"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18",
+      "@types/react-dom": "^18"
+    },
+    "dependencies": {
+      "react": "18.0.0",
+      "react-dom": "18.0.0"
+    }
+  },
   "localPeerDependencies": {
     "react-scrolling-background": "^0.0.0-0"
   },

--- a/packages/react-scrolling-background/package.json
+++ b/packages/react-scrolling-background/package.json
@@ -62,8 +62,25 @@
     "url": "https://github.com/compulim/react-scrolling-background/issues"
   },
   "homepage": "https://github.com/compulim/react-scrolling-background#readme",
+  "switch:react:16": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^16"
+    }
+  },
+  "switch:react:17": {
+    "devDependencies": {
+      "@testing-library/react": "^12",
+      "@types/react": "^17"
+    }
+  },
+  "switch:react:18": {
+    "devDependencies": {
+      "@types/react": "^18"
+    }
+  },
   "peerDependencies": {
-    "react": ">=16.9.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.0",


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Changed

- Relaxed peer dependencies requirements to `react@>=16.8.0`, by [@compulim](https://github.com/compulim) in PR [#2](https://github.com/compulim/react-scrolling-background/pull/2)

## Specific changes

> Please list each individual specific change in this pull request.

- Update `/packages/react-scrolling-background/package.json/peerDependencies/react` to `>=16.8.0`